### PR TITLE
renamed readers to members

### DIFF
--- a/doc/couch_admin.md
+++ b/doc/couch_admin.md
@@ -19,18 +19,18 @@ This section give details about the CouchAdmin object.
     + [addRoleToUser($user, $role)](#addroletouseruser-role)
     + [removeRoleFromUser($user, $role)](#removerolefromuseruser-role)
 - [Database user security](#database-user-security)
-    + [addDatabaseReaderUser($login)](#adddatabasereaderuserlogin)
+    + [addDatabaseMemberUser($login)](#adddatabasememberuserlogin)
     + [addDatabaseAdminUser($login)](#adddatabaseadminuserlogin)
-    + [getDatabaseReaderUsers()](#getdatabasereaderusers)
+    + [getDatabaseMemberUsers()](#getdatabasememberusers)
     + [getDatabaseAdminUsers()](#getdatabaseadminusers)
-    + [removeDatabaseReaderUser($login)](#removedatabasereaderuserlogin)
+    + [removeDatabaseMemberUser($login)](#removedatabasememberuserlogin)
     + [removeDatabaseAdminUser($login)](#removedatabaseadminuserlogin)
 - [Database roles security](#database-roles-security)
-    + [addDatabaseReaderRole($role)](#adddatabasereaderrolerole)
+    + [addDatabaseMemberRole($role)](#adddatabasememberrolerole)
     + [addDatabaseAdminRole($role)](#adddatabaseadminrolerole)
-    + [getDatabaseReaderRoles()](#getdatabasereaderroles)
+    + [getDatabaseMemberRoles()](#getdatabasememberroles)
     + [getDatabaseAdminRoles()](#getdatabaseadminroles)
-    + [removeDatabaseReaderRole($role)](#removedatabasereaderrolerole)
+    + [removeDatabaseMemberRole($role)](#removedatabasememberrolerole)
     + [removeDatabaseAdminRole($role)](#removedatabaseadminrole-role)
 - [Accessing Database security object](#accessing-database-security-object)
     + [getSecurity()](#getsecurity)
@@ -104,15 +104,15 @@ The **CouchAdmin** class contains helpful methods to create admins, users, and a
         die("unable to remove joe from the admins list of mydb: ".$e->getMessage());
     }
     
-    // and add it to the readers group of database "mydb"
+    // and add it to the members group of database "mydb"
     try {
-        $adm->addDatabaseReaderUser("joe");
+        $adm->addDatabaseMemberUser("joe");
     } catch ( Exception $e ) {
-        die("unable to add joe to the readers list of mydb: ".$e->getMessage());
+        die("unable to add joe to the members list of mydb: ".$e->getMessage());
     }
     
-    // well... get the list of users belonging to the "readers" group of "mydb"
-    $users = $adm->getDatabaseReaderUsers();  // array ( "joe" )
+    // well... get the list of users belonging to the "members" group of "mydb"
+    $users = $adm->getDatabaseMemberUsers();  // array ( "joe" )
     
 
 ##Getting started
@@ -450,16 +450,16 @@ Example : removing the role *cowboy* of user *joe*
 
 ##Database user security
 
-CouchDB databases got two types of privileged users : the *readers*, that can read all documents, and only write normal (non-design) documents.
-The *admins* got all privileges of the *readers*, and they also can write design documents, use temporary views, add and remove *readers* and *admins* of the database.
+CouchDB databases got two types of privileged users : the *members*, that can read all documents, and only write normal (non-design) documents.
+The *admins* got all privileges of the *members*, and they also can write design documents, use temporary views, add and remove *members* and *admins* of the database.
 [The CouchDB wiki gives all details regarding rights management.](http://wiki.apache.org/couchdb/Security_Features_Overview)
 
 
-###addDatabaseReaderUser($login)
+###addDatabaseMemberUser($login)
 
-The method **addDatabaseReaderUser($login)** adds a user in the readers list of the database.
+The method **addDatabaseMemberUser($login)** adds a user in the members list of the database.
 
-Example - adding joe to the readers of the database mydb
+Example - adding joe to the members of the database mydb
 
     <?PHP
     use PHPOnCouch\Couch,
@@ -469,7 +469,7 @@ Example - adding joe to the readers of the database mydb
     $adm = new CouchAdmin($client);
     
     try {
-        $adm->addDatabaseReaderUser("joe");
+        $adm->addDatabaseMemberUser("joe");
     } catch ( Exception $e ) {
         die("unable to add user: ".$e->getMessage());
     }
@@ -495,11 +495,11 @@ Example - adding joe to the admins of the database mydb
     }
 
 
-###getDatabaseReaderUsers()
+###getDatabaseMemberUsers()
 
-The method **getDatabaseReaderUsers()** returns the list of users belonging to the *readers* of the database.
+The method **getDatabaseMemberUsers()** returns the list of users belonging to the *members* of the database.
 
-Example - getting all users beeing *readers* of the database mydb
+Example - getting all users beeing *members* of the database mydb
 
     <?PHP
     use PHPOnCouch\Couch,
@@ -509,7 +509,7 @@ Example - getting all users beeing *readers* of the database mydb
     $adm = new CouchAdmin($client);
     
     try {
-        $users = $adm->getDatabaseReaderUsers();
+        $users = $adm->getDatabaseMemberUsers();
     } catch ( Exception $e ) {
         die("unable to list users: ".$e->getMessage());
     }
@@ -539,11 +539,11 @@ Example - getting all users beeing *admins* of the database mydb
     // will echo something like: Array ( "william" )
 
 
-###removeDatabaseReaderUser($login)
+###removeDatabaseMemberUser($login)
 
-The method **removeDatabaseReaderUser($login)** removes a user from the readers list of the database.
+The method **removeDatabaseMemberUser($login)** removes a user from the members list of the database.
 
-Example - removing joe from the readers of the database mydb
+Example - removing joe from the members of the database mydb
 
     <?PHP
     use PHPOnCouch\Couch,
@@ -553,7 +553,7 @@ Example - removing joe from the readers of the database mydb
     $adm = new CouchAdmin($client);
     
     try {
-        $adm->removeDatabaseReaderUser("joe");
+        $adm->removeDatabaseMemberUser("joe");
     } catch ( Exception $e ) {
         die("unable to remove user: ".$e->getMessage());
     }
@@ -582,15 +582,15 @@ Example - removing joe from the admins of the database mydb
 
 ##Database roles security
 
-Just like users, roles can be assigned as admins or readers in a CouchDB database.
+Just like users, roles can be assigned as admins or members in a CouchDB database.
 [The CouchDB wiki gives all details regarding rights management.](http://wiki.apache.org/couchdb/Security_Features_Overview)
 
 
-###addDatabaseReaderRole($role)
+###addDatabaseMemberRole($role)
 
-The method **addDatabaseReaderrole($role)** adds a role in the readers list of the database.
+The method **addDatabaseMemberrole($role)** adds a role in the members list of the database.
 
-Example - adding cowboy to the readers of the database mydb
+Example - adding cowboy to the members of the database mydb
 
     <?PHP
     use PHPOnCouch\Couch,
@@ -600,7 +600,7 @@ Example - adding cowboy to the readers of the database mydb
     $adm = new CouchAdmin($client);
     
     try {
-        $adm->addDatabaseReaderRole("cowboy");
+        $adm->addDatabaseMemberRole("cowboy");
     } catch ( Exception $e ) {
         die("unable to add role: ".$e->getMessage());
     }
@@ -626,11 +626,11 @@ Example - adding *cowboy* role to the *admins* of the database mydb
     }
 
 
-###getDatabaseReaderRoles()
+###getDatabaseMemberRoles()
 
-The method **getDatabaseReaderRoles()** returns the list of roles belonging to the *readers* of the database.
+The method **getDatabaseMemberRoles()** returns the list of roles belonging to the *members* of the database.
 
-Example - getting all roles beeing *readers* of the database mydb
+Example - getting all roles beeing *members* of the database mydb
 
     <?PHP
     use PHPOnCouch\Couch,
@@ -640,7 +640,7 @@ Example - getting all roles beeing *readers* of the database mydb
     $adm = new CouchAdmin($client);
     
     try {
-        $roles = $adm->getDatabaseReaderRoles();
+        $roles = $adm->getDatabaseMemberRoles();
     } catch ( Exception $e ) {
         die("unable to list roles: ".$e->getMessage());
     }
@@ -670,11 +670,11 @@ Example - getting all roles beeing *admins* of the database mydb
     // will echo something like: Array ( "martians" )
 
 
-###removeDatabaseReaderRole($role)
+###removeDatabaseMemberRole($role)
 
-The method **removeDatabaseReaderRole($role)** removes a role from the readers list of the database.
+The method **removeDatabaseMemberRole($role)** removes a role from the members list of the database.
 
-Example - removing *cowboy* from the *readers* of the database mydb
+Example - removing *cowboy* from the *members* of the database mydb
 
     <?PHP
     use PHPOnCouch\Couch,
@@ -684,7 +684,7 @@ Example - removing *cowboy* from the *readers* of the database mydb
     $adm = new CouchAdmin($client);
     
     try {
-        $adm->removeDatabaseReaderRole("cowboy");
+        $adm->removeDatabaseMemberRole("cowboy");
     } catch ( Exception $e ) {
         die("unable to remove role: ".$e->getMessage());
     }
@@ -721,7 +721,7 @@ Each Couch database got a security object. The security object is made like :
             "names" : ["joe", "phil"],
             "roles" : ["boss"]
         },
-        "readers" : {
+        "members" : {
             "names" : ["dave"],
             "roles" : ["producer", "consumer"]
         }

--- a/src/CouchAdmin.php
+++ b/src/CouchAdmin.php
@@ -333,9 +333,9 @@ class CouchAdmin
 			$resp["body"]->admins = new stdClass();
 			$resp["body"]->admins->names = array();
 			$resp["body"]->admins->roles = array();
-			$resp["body"]->readers = new stdClass();
-			$resp["body"]->readers->names = array();
-			$resp["body"]->readers->roles = array();
+			$resp["body"]->members = new stdClass();
+			$resp["body"]->members->names = array();
+			$resp["body"]->members->roles = array();
 		}
 		return $resp['body'];
 	}
@@ -365,22 +365,22 @@ class CouchAdmin
 	}
 
 	/**
-	 * add a user to the list of readers for the current database
+	 * add a user to the list of members for the current database
 	 *
 	 * @param string $login user login
 	 * @return boolean true if the user has successfuly been added
 	 * @throws InvalidArgumentException
 	 */
-	public function addDatabaseReaderUser($login)
+	public function addDatabaseMemberUser($login)
 	{
 		if (strlen($login) < 1) {
 			throw new InvalidArgumentException("Login can't be empty");
 		}
 		$sec = $this->getSecurity();
-		if (in_array($login, $sec->readers->names)) {
+		if (in_array($login, $sec->members->names)) {
 			return true;
 		}
-		array_push($sec->readers->names, $login);
+		array_push($sec->members->names, $login);
 		$back = $this->setSecurity($sec);
 		if (is_object($back) && property_exists($back, "ok") && $back->ok == true) {
 			return true;
@@ -424,33 +424,33 @@ class CouchAdmin
 	}
 
 	/**
-	 * get the list of readers for the current database
+	 * get the list of members for the current database
 	 *
-	 * @return array database readers logins
+	 * @return array database members logins
 	 */
-	public function getDatabaseReaderUsers()
+	public function getDatabaseMemberUsers()
 	{
 		$sec = $this->getSecurity();
-		return $sec->readers->names;
+		return $sec->members->names;
 	}
 
 	/**
-	 * remove a user from the list of readers for the current database
+	 * remove a user from the list of members for the current database
 	 *
 	 * @param string $login user login
 	 * @return boolean true if the user has successfuly been removed
 	 * @throws InvalidArgumentException
 	 */
-	public function removeDatabaseReaderUser($login)
+	public function removeDatabaseMemberUser($login)
 	{
 		if (strlen($login) < 1) {
 			throw new InvalidArgumentException("Login can't be empty");
 		}
 		$sec = $this->getSecurity();
-		if (!in_array($login, $sec->readers->names)) {
+		if (!in_array($login, $sec->members->names)) {
 			return true;
 		}
-		$sec->readers->names = $this->rmFromArray($login, $sec->readers->names);
+		$sec->members->names = $this->rmFromArray($login, $sec->members->names);
 		$back = $this->setSecurity($sec);
 		if (is_object($back) && property_exists($back, "ok") && $back->ok == true) {
 			return true;
@@ -485,22 +485,22 @@ class CouchAdmin
 /// roles
 
 	/**
-	 * add a role to the list of readers for the current database
+	 * add a role to the list of members for the current database
 	 *
 	 * @param string $role role name
 	 * @return boolean true if the role has successfuly been added
 	 * @throws InvalidArgumentException
 	 */
-	public function addDatabaseReaderRole($role)
+	public function addDatabaseMemberRole($role)
 	{
 		if (strlen($role) < 1) {
 			throw new InvalidArgumentException("Role can't be empty");
 		}
 		$sec = $this->getSecurity();
-		if (in_array($role, $sec->readers->roles)) {
+		if (in_array($role, $sec->members->roles)) {
 			return true;
 		}
-		array_push($sec->readers->roles, $role);
+		array_push($sec->members->roles, $role);
 		$back = $this->setSecurity($sec);
 		if (is_object($back) && property_exists($back, "ok") && $back->ok == true) {
 			return true;
@@ -544,33 +544,33 @@ class CouchAdmin
 	}
 
 	/**
-	 * get the list of reader roles for the current database
+	 * get the list of member roles for the current database
 	 *
-	 * @return array database readers roles
+	 * @return array database members roles
 	 */
-	public function getDatabaseReaderRoles()
+	public function getDatabaseMemberRoles()
 	{
 		$sec = $this->getSecurity();
-		return $sec->readers->roles;
+		return $sec->members->roles;
 	}
 
 	/**
-	 * remove a role from the list of readers for the current database
+	 * remove a role from the list of members for the current database
 	 *
 	 * @param string $role role name
 	 * @return boolean true if the role has successfuly been removed
 	 * @throws InvalidArgumentException
 	 */
-	public function removeDatabaseReaderRole($role)
+	public function removeDatabaseMemberRole($role)
 	{
 		if (strlen($role) < 1) {
 			throw new InvalidArgumentException("Role can't be empty");
 		}
 		$sec = $this->getSecurity();
-		if (!in_array($role, $sec->readers->roles)) {
+		if (!in_array($role, $sec->members->roles)) {
 			return true;
 		}
-		$sec->readers->roles = $this->rmFromArray($role, $sec->readers->roles);
+		$sec->members->roles = $this->rmFromArray($role, $sec->members->roles);
 		$back = $this->setSecurity($sec);
 		if (is_object($back) && property_exists($back, "ok") && $back->ok == true) {
 			return true;

--- a/src/CouchAdmin.php
+++ b/src/CouchAdmin.php
@@ -333,6 +333,8 @@ class CouchAdmin
 			$resp["body"]->admins = new stdClass();
 			$resp["body"]->admins->names = array();
 			$resp["body"]->admins->roles = array();
+		}
+		if (!property_exists($resp['body'], "members")) {
 			$resp["body"]->members = new stdClass();
 			$resp["body"]->members->names = array();
 			$resp["body"]->members->roles = array();

--- a/src/CouchClient.php
+++ b/src/CouchClient.php
@@ -246,7 +246,7 @@ class CouchClient extends Couch
 	{
 		if ($dbname == "_users")
 			return true;
-		if (preg_match("@^[a-z][a-z0-9_\$\(\)\+\-/]*$@", $dbname))
+		if (preg_match("@^[a-z0-9_\$\(\)\+\-/]*$@", $dbname))
 			return true;
 		return false;
 	}

--- a/src/CouchReplicator.php
+++ b/src/CouchReplicator.php
@@ -17,6 +17,8 @@
 
 namespace PHPOnCouch;
 
+use PHPOnCouch\Exceptions\CouchException;
+
 /**
  * Special class to handle replication stuff, as the API is still evolving
  *

--- a/tests/CouchAdminTest.php
+++ b/tests/CouchAdminTest.php
@@ -213,11 +213,11 @@ class CouchAdminTest extends \PHPUnit_Framework_TestCase
 		$adm = new CouchAdmin($this->aclient);
 		$security = $adm->getSecurity();
 		$this->assertObjectHasAttribute("admins", $security);
-		$this->assertObjectHasAttribute("readers", $security);
+		$this->assertObjectHasAttribute("members", $security);
 		$this->assertObjectHasAttribute("names", $security->admins);
 		$this->assertObjectHasAttribute("roles", $security->admins);
-		$this->assertObjectHasAttribute("names", $security->readers);
-		$this->assertObjectHasAttribute("roles", $security->readers);
+		$this->assertObjectHasAttribute("names", $security->members);
+		$this->assertObjectHasAttribute("roles", $security->members);
 	}
 
 	/**
@@ -228,36 +228,36 @@ class CouchAdminTest extends \PHPUnit_Framework_TestCase
 		$adm = new CouchAdmin($this->aclient);
 		$security = $adm->getSecurity();
 		$security->admins->names[] = "joe";
-		$security->readers->names[] = "jack";
+		$security->members->names[] = "jack";
 		$ok = $adm->setSecurity($security);
 		$this->assertInternalType("object", $ok);
 		$this->assertObjectHasAttribute("ok", $ok);
 		$this->assertEquals($ok->ok, true);
 
 		$security = $adm->getSecurity();
-		$this->assertEquals(count($security->readers->names), 1);
-		$this->assertEquals(reset($security->readers->names), "jack");
+		$this->assertEquals(count($security->members->names), 1);
+		$this->assertEquals(reset($security->members->names), "jack");
 		$this->assertEquals(count($security->admins->names), 1);
 		$this->assertEquals(reset($security->admins->names), "joe");
 	}
 
 	/**
-	 * @covers PHPOnCouch\CouchAdmin::addDatabaseReaderUser
+	 * @covers PHPOnCouch\CouchAdmin::addDatabaseMemberUser
 	 */
-	public function testAddDatabaseReaderUser()
+	public function testAddDatabaseMemberUser()
 	{
 		$adm = new CouchAdmin($this->aclient);
-		$ok = $adm->removeDatabaseReaderUser("jack");
+		$ok = $adm->removeDatabaseMemberUser("jack");
 		$this->assertInternalType("boolean", $ok);
 		$this->assertEquals($ok, true);
 		$security = $adm->getSecurity();
-		$this->assertEquals(count($security->readers->names), 0);
-		$ok = $adm->addDatabaseReaderUser("jack");
+		$this->assertEquals(count($security->members->names), 0);
+		$ok = $adm->addDatabaseMemberUser("jack");
 		$this->assertInternalType("boolean", $ok);
 		$this->assertEquals($ok, true);
 		$security = $adm->getSecurity();
-		$this->assertEquals(count($security->readers->names), 1);
-		$this->assertEquals(reset($security->readers->names), "jack");
+		$this->assertEquals(count($security->members->names), 1);
+		$this->assertEquals(reset($security->members->names), "jack");
 	}
 
 	/**
@@ -298,28 +298,28 @@ class CouchAdminTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @covers PHPOnCouch\CouchAdmin::getDatabaseReaderUsers
-	 * @depends testAddDatabaseReaderUser
+	 * @covers PHPOnCouch\CouchAdmin::getDatabaseMemberUsers
+	 * @depends testAddDatabaseMemberUser
 	 */
-	public function testGetDatabaseReaderUsers()
+	public function testGetDatabaseMemberUsers()
 	{
 		$adm = new CouchAdmin($this->aclient);
-		$users = $adm->getDatabaseReaderUsers();
+		$users = $adm->getDatabaseMemberUsers();
 		$this->assertInternalType("array", $users);
 		$this->assertEquals(0, count($users));
 
-		$adm->addDatabaseReaderUser("jack");
-		$users = $adm->getDatabaseReaderUsers();
+		$adm->addDatabaseMemberUser("jack");
+		$users = $adm->getDatabaseMemberUsers();
 		$this->assertInternalType("array", $users);
 		$this->assertEquals(1, count($users));
 		$this->assertEquals("jack", reset($users));
 	}
 
 	/**
-	 * @covers PHPOnCouch\CouchAdmin::removeDatabaseReaderUser
-	 * @todo   Implement testRemoveDatabaseReaderUser().
+	 * @covers PHPOnCouch\CouchAdmin::removeDatabaseMemberUser
+	 * @todo   Implement testRemoveDatabaseMemberUser().
 	 */
-	public function testRemoveDatabaseReaderUser()
+	public function testRemoveDatabaseMemberUser()
 	{
 		// Remove the following lines when you implement this test.
 		$this->markTestIncomplete(
@@ -340,24 +340,24 @@ class CouchAdminTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @covers PHPOnCouch\CouchAdmin::addDatabaseReaderRole
+	 * @covers PHPOnCouch\CouchAdmin::addDatabaseMemberRole
 	 */
-	public function testAddDatabaseReaderRole()
+	public function testAddDatabaseMemberRole()
 	{
 		$adm = new CouchAdmin($this->aclient);
 		$security = $adm->getSecurity();
-		$this->assertEquals(count($security->readers->roles), 0);
-		$ok = $adm->addDatabaseReaderRole("cowboy");
+		$this->assertEquals(count($security->members->roles), 0);
+		$ok = $adm->addDatabaseMemberRole("cowboy");
 		$this->assertInternalType("boolean", $ok);
 		$this->assertEquals($ok, true);
 		$security = $adm->getSecurity();
-		$this->assertEquals(count($security->readers->roles), 1);
-		$this->assertEquals(reset($security->readers->roles), "cowboy");
-		$ok = $adm->removeDatabaseReaderRole("cowboy");
+		$this->assertEquals(count($security->members->roles), 1);
+		$this->assertEquals(reset($security->members->roles), "cowboy");
+		$ok = $adm->removeDatabaseMemberRole("cowboy");
 		$this->assertInternalType("boolean", $ok);
 		$this->assertEquals($ok, true);
 		$security = $adm->getSecurity();
-		$this->assertEquals(count($security->readers->roles), 0);
+		$this->assertEquals(count($security->members->roles), 0);
 	}
 
 	/**
@@ -393,22 +393,22 @@ class CouchAdminTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @covers PHPOnCouch\CouchAdmin::getDatabaseReaderRoles
-	 * @todo   Implement testGetDatabaseReaderRoles().
+	 * @covers PHPOnCouch\CouchAdmin::getDatabaseMemberRoles
+	 * @todo   Implement testGetDatabaseMemberRoles().
 	 */
-	public function testGetDatabaseReaderRoles()
+	public function testGetDatabaseMemberRoles()
 	{
 		$adm = new CouchAdmin($this->aclient);
-		$users = $adm->getDatabaseReaderRoles();
+		$users = $adm->getDatabaseMemberRoles();
 		$this->assertInternalType("array", $users);
 		$this->assertEquals(0, count($users));
 	}
 
 	/**
-	 * @covers PHPOnCouch\CouchAdmin::removeDatabaseReaderRole
-	 * @todo   Implement testRemoveDatabaseReaderRole().
+	 * @covers PHPOnCouch\CouchAdmin::removeDatabaseMemberRole
+	 * @todo   Implement testRemoveDatabaseMemberRole().
 	 */
-	public function testRemoveDatabaseReaderRole()
+	public function testRemoveDatabaseMemberRole()
 	{
 		// Remove the following lines when you implement this test.
 		$this->markTestIncomplete(


### PR DESCRIPTION
CouchDB documentation states that _security object contains admins and members, not readers. although readers seems to be accepted and working same as members, they are not shown at Fauxton and it may lead to confusion and may lead to other issues in the future. 

This PR updates all mentions of 'reader' to 'member' to match CouchDB terminology and docs.